### PR TITLE
include java/scala-doc in the documentation

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -20,7 +20,7 @@ jobs:
          CFIO_TOKEN: ${{ secrets.CLOUDFLOWIO_TOKEN }}
       run: |
         git clone https://${CFIO_USER}:${CFIO_TOKEN}@github.com/lightbend/cloudflow.io.git ./cloudflow.io
-        cp -r docs-source/build/site/* ./cloudflow.io
+        cp -r target/staging/* ./cloudflow.io
         cd ./cloudflow.io
         git config  user.email "$CFIO_EMAIL"
         git config  user.name "$CFIO_USER"

--- a/docs-source/author-mode-site.yml
+++ b/docs-source/author-mode-site.yml
@@ -27,8 +27,7 @@ asciidoc:
     todo: ''
     
     doc-title: 'Cloudflow Guide'
-                     
 
 output:
-#   dir: ./
-   clean: true
+  dir: ./../target/staging
+  clean: true

--- a/docs-source/docs/modules/ROOT/nav.adoc
+++ b/docs-source/docs/modules/ROOT/nav.adoc
@@ -26,3 +26,7 @@
 ** xref:develop:use-flink-streamlets.adoc[Using Flink streamlets]
 *** xref:develop:build-flink-streamlets.adoc[Building a Flink streamlet]
 *** xref:develop:test-flink-streamlet.adoc[Testing a Flink streamlet]
+
+* xref:api:index.adoc[Streamlet API]
+** link:./scaladoc/cloudflow/streamlets/index.html[Scaladoc]
+** link:./javadoc/[Javadoc]

--- a/docs-source/docs/modules/ROOT/nav.adoc
+++ b/docs-source/docs/modules/ROOT/nav.adoc
@@ -29,4 +29,4 @@
 
 * xref:api:index.adoc[Streamlet API]
 ** link:./scaladoc/cloudflow/streamlets/index.html[Scaladoc]
-** link:./javadoc/[Javadoc]
+** link:./javadoc/index.html[Javadoc]

--- a/docs-source/docs/modules/api/pages/index.adoc
+++ b/docs-source/docs/modules/api/pages/index.adoc
@@ -1,0 +1,8 @@
+= Cloudflow Streamlet API
+:toc:
+:toc-title: ON THIS PAGE
+:toclevels: 2
+:description: The Streamlet abstraction lets you simplify the development of stages of a distributed streaming application.
+
+- link:./scaladoc/cloudflow/streamlets/index.html[Streamlet API - Scaladoc]
+- link:./javadoc/[Streamlet API - Javadoc]

--- a/docs-source/docs/modules/api/pages/index.adoc
+++ b/docs-source/docs/modules/api/pages/index.adoc
@@ -5,4 +5,4 @@
 :description: The Streamlet abstraction lets you simplify the development of stages of a distributed streaming application.
 
 - link:./scaladoc/cloudflow/streamlets/index.html[Streamlet API - Scaladoc]
-- link:./javadoc/[Streamlet API - Javadoc]
+- link:./javadoc/index.html[Streamlet API - Javadoc]

--- a/docs-source/site.yml
+++ b/docs-source/site.yml
@@ -29,5 +29,5 @@ asciidoc:
     doc-title: 'Cloudflow Guide'
 
 output:
-#   dir: ./
+   dir: ./../target/staging
    clean: true


### PR DESCRIPTION
This PR refactors the `Makefile` to streamline the Antora generation and include the scala/java docs in the document structure.
It separates the generated content to a `/target` dir.
It updates the GitHub action to use the new structure.