### PR TITLE
removes the API links from the index 

### DIFF
--- a/docs-source/docs/modules/ROOT/nav.adoc
+++ b/docs-source/docs/modules/ROOT/nav.adoc
@@ -29,6 +29,4 @@
 *** xref:develop:build-flink-streamlets.adoc[Building a Flink streamlet]
 *** xref:develop:test-flink-streamlet.adoc[Testing a Flink streamlet]
 
-* xref:api:index.adoc[Streamlet API]
-** link:./scaladoc/cloudflow/streamlets/index.html[Scaladoc]
-** link:./javadoc/index.html[Javadoc]
+* xref:api:index.adoc[Streamlet API Reference]


### PR DESCRIPTION
These relative links are not being properly handled, causing a broken link when the menu item is closed but the links are visible (the user didn't click on 'Cloudflow API')