### PR TITLE
Uses new video format

### DIFF
--- a/docs-source/docs/modules/ROOT/pages/index.adoc
+++ b/docs-source/docs/modules/ROOT/pages/index.adoc
@@ -8,7 +8,7 @@ include::partial$include.adoc[]
 
 Cloudflow enables you to quickly develop distributed streaming applications to deploy on Kubernetes. The rapid advance and adoption of the Kubernetes ecosystem is delivering on the devops promise of giving control and responsibility to dev teams over the lifecycle of their applications. However, use of Kubernetes also increases the complexity of delivering end-to-end applications. Cloudflow alleviates that pain for distributed streaming applications, which are often far more complex than typical front-end or microservice deployments.
 
-video::-9pVwCkkE1I[youtube,width=600,height=400]
+link:https://www.youtube.com/watch?v=-9pVwCkkE1I[Watch on YouTube ,role=yt-widget]
 
 Cloudflow integrates with popular streaming engines like Akka, Apache Spark, and Apache Flink. Using Cloudflow, you can easily break down your streaming application into small composable components and wire them together with schema-based contracts. With its powerful abstractions, Cloudflow enables you to define, build and deploy the most complex streaming applications. 
 

--- a/homepage-source/docs/modules/ROOT/pages/index.adoc
+++ b/homepage-source/docs/modules/ROOT/pages/index.adoc
@@ -8,7 +8,7 @@ Cloudflow enables you to quickly develop, orchestrate, and operate distributed s
 With Cloudflow, streaming applications are comprised of small composable components wired together with schema-based contracts. 
 Cloudflow can dramatically accelerate streaming application development--reducing the time required to create, package, and deploy--from weeks to hours. 
 
-video::-9pVwCkkE1I[youtube,width=800,height=540]
+link:https://www.youtube.com/watch?v=-9pVwCkkE1I[Watch on YouTube ,role=yt-widget]
 
 With its powerful abstractions, Cloudflow allows you to easily define the most complex streaming applications:
 


### PR DESCRIPTION
Fixes #41 

<!--
Please clarify why the changes are needed. 
-->

Richard added styling for videos and GDPR so that the viewer must accept cookies or watch on youtube directly. This change from video:: to the link: format takes advantage of that.