### PR TITLE
Fixes some broken links found when sharing with enterprise docs

### DIFF
--- a/docs-source/docs/modules/ROOT/pages/index.adoc
+++ b/docs-source/docs/modules/ROOT/pages/index.adoc
@@ -60,6 +60,6 @@ Choose from the following topics:
 
 * xref:app-development-process.adoc[The Cloudflow development process]
 * xref:get-started:index.adoc[How to get started with an example application]
-* xref:develop:cloudflow-streamlets.adoc[How to create Cloudflow applications using streamlets and blueprints].
+* xref:develop:develop.adoc[How to create Cloudflow applications using streamlets and blueprints].
 
 **This guide last published: {localdate}**

--- a/docs-source/docs/modules/develop/pages/index.adoc
+++ b/docs-source/docs/modules/develop/pages/index.adoc
@@ -6,6 +6,6 @@
 
 
 include::ROOT:partial$include.adoc[]
-include::shared-content:develop:page$cloudflow-streamlets.adoc[]
+include::shared-content:develop:page$index.adoc[]
 
 // Authors: content in this file is included from the ./../shared-content-source directory. Please see the readme in that folder before editing shared content.

--- a/shared-content-source/README.adoc
+++ b/shared-content-source/README.adoc
@@ -8,7 +8,7 @@ Sharing content requires a source page, an including page, and a directive that 
 
 . The source of a shared content page must include the attribute `:page-partial:` and *not* include a title. You can see an example in `./docs/modules/develop/pages/cloudflow-streamlet.adoc`. 
 
-. To use shared content, you use an `include` directive. For example, in this open source documentation repository, the `docs-source/docs/modules/develop/pages/index.html` file includes this shared file, using this directive: `include::shared-content:develop:page$cloudflow-streamlets.adoc[]`.
+. To use shared content, you use an `include` directive. For example, in this open source documentation repository, the `docs-source/docs/modules/develop/pages/index.html` file includes this shared file, using this directive: `include::shared-content:develop:page$index.adoc[]`.
 
 . In the `site.yml` (and, if you use it, the `author-mode-site.yml`), you must declare the `shared-content-source` as a `source` in the `content` element. The name of the component is set in the `shared-content-source/docs/antora.yml` file. In this repository, that name is `shared-content`, which is referenced in `site.yml` as:
 +

--- a/shared-content-source/docs/modules/develop/pages/build-akka-streamlets.adoc
+++ b/shared-content-source/docs/modules/develop/pages/build-akka-streamlets.adoc
@@ -184,7 +184,7 @@ You can access the inlet and outlet streams through methods on the `StreamletLog
 So far, we've used the `plainSource` method to read from the inlet.
 When the streamlet is started, it will only receive elements that arrive *after* it is started. 
 The same applies when the streamlet is restarted for any reason. 
-In short, the `plainSource` provides at-most-once message delivery semantics, as described in xref:cloudflow-streamlets.adoc#message-delivery-semantics[Message delivery semantics].
+In short, the `plainSource` provides at-most-once message delivery semantics, as described in xref:index.adoc#message-delivery-semantics[Message delivery semantics].
 
 [NOTE]
 ====
@@ -310,4 +310,4 @@ Java::
 include::{code-snippets-version}@docsnippets:ROOT:example$build-akka-streamlets-java/step3/src/main/java/com/example/AtLeastOnceReportPrinter.java[tag=atLeastOnce]
 ----
 
-This completes the code for the `ReportPrinter`. The next step is to use it in a blueprint, as described in xref:cloudflow-streamlets.adoc#streamlets-blueprints[Composing streamlets using blueprints]. Then, you will want to xref:test-akka-streamlet.adoc[test your streamlets].
+This completes the code for the `ReportPrinter`. The next step is to use it in a blueprint, as described in xref:index.adoc#streamlets-blueprints[Composing streamlets using blueprints]. Then, you will want to xref:test-akka-streamlet.adoc[test your streamlets].

--- a/shared-content-source/docs/modules/develop/pages/index.adoc
+++ b/shared-content-source/docs/modules/develop/pages/index.adoc
@@ -376,7 +376,9 @@ The format for specifying configuration parameter values is as follows:
 
     [streamlet name].[configuration parameter name]="[value]"
 
-Deploying an application without specifying values for all required configuration parameters will fail and result in an error message like this:
+Deploying an application without specifying values for all required configuration parameters will fail and result in an error message like the following.
+
+NOTE: Examples in this section show the OpenShift `oc plugin`, however you should substitute the correct command for your K8s distribution.
 
 [source,bash,subs=attributes+]
 ----

--- a/shared-content-source/docs/modules/develop/pages/use-akka-streamlets.adoc
+++ b/shared-content-source/docs/modules/develop/pages/use-akka-streamlets.adoc
@@ -5,7 +5,7 @@ An Akka-based streamlet has the following responsibilities:
 * Capturing your stream processing logic.
 * Publishing metadata which will be used by the `sbt-cloudflow` plugin to verify that a blueprint is correct.
   This metadata consists of the _shape_ of the streamlet (`StreamletShape`) defined by the inlets and outlets of the streamlet.
-  Connecting streamlets need to match on inlets and outlets to make a valid cloudflow topology, as mentioned previously in xref:cloudflow-streamlets.adoc#streamlets-blueprints[Composing streamlets using blueprints].
+  Connecting streamlets need to match on inlets and outlets to make a valid cloudflow topology, as mentioned previously in xref:index.adoc#streamlets-blueprints[Composing streamlets using blueprints].
   Cloudflow automatically extracts the shapes from the streamlets to verify this match.
 * For the Cloudflow runtime, it needs to provide metadata so that it can be configured, scaled, and run as part of an application.
 * The inlets and outlets of a `Streamlet` have two functions:
@@ -75,7 +75,7 @@ that are available for how to continue processing data after a restart.
 [[message-delivery-semantics-akka]]
 == Message delivery semantics
 
-If you only want to process data that is arriving in real-time—ignoring data from the past—an Akka streamlet can simply start from the most recently arrived record. In this case, an _at-most-once_ semantics is used (see xref:cloudflow-streamlets.adoc#message-delivery-semantics[Message delivery semantics]). The streamlet will process data as it arrives. Data that arrives while the streamlet is not running will not be processed. 
+If you only want to process data that is arriving in real-time—ignoring data from the past—an Akka streamlet can simply start from the most recently arrived record. In this case, an _at-most-once_ semantics is used (see xref:index.adoc#message-delivery-semantics[Message delivery semantics]). The streamlet will process data as it arrives. Data that arrives while the streamlet is not running will not be processed. 
 
 At-most-once message delivery semantics are applied to Akka streamlets that use standard Akka Stream graphs like `Source`, `Sink`, `Flow`.
 

--- a/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -5,7 +5,7 @@ A Flink streamlet has the following responsibilities:
 * It needs to capture your stream processing logic.
 * It needs to publish metadata used by the `sbt-cloudflow` plugin to verify that a blueprint is correct.
   This metadata consists of the _shape_ of the streamlet (`StreamletShape`) defined by the inlets and outlets of the streamlet.
-  Connecting streamlets need to match on inlets and outlets to make a valid cloudflow topology, as mentioned previously in xref:cloudflow-streamlets.adoc#streamlets-blueprints[Composing streamlets using blueprints].
+  Connecting streamlets need to match on inlets and outlets to make a valid cloudflow topology, as mentioned previously in xref:index.adoc#streamlets-blueprints[Composing streamlets using blueprints].
   Cloudflow automatically extracts the shapes from the streamlets to verify this match.
 * For the Cloudflow runtime, it needs to provide metadata so that it can be configured, scaled, and run as part of an application.
 * The inlets and outlets of a `Streamlet` have two functions:

--- a/shared-content-source/docs/modules/develop/pages/use-spark-streamlets.adoc
+++ b/shared-content-source/docs/modules/develop/pages/use-spark-streamlets.adoc
@@ -7,7 +7,7 @@ A Spark streamlet has the following responsibilities:
 * It needs to capture your stream processing logic.
 * It needs to publish metadata which will be used by the `sbt-cloudflow` plugin to verify that a blueprint is correct.
   This metadata consists of the _shape_ of the streamlet (`StreamletShape`) defined by the inlets and outlets of the streamlet.
-  Connecting streamlets need to match on inlets and outlets to make a valid cloudflow topology, as mentioned previously in xref:cloudflow-streamlets.adoc#streamlets-blueprints[Composing streamlets using blueprints].
+  Connecting streamlets need to match on inlets and outlets to make a valid cloudflow topology, as mentioned previously in xref:index.adoc#streamlets-blueprints[Composing streamlets using blueprints].
   Cloudflow automatically extracts the shapes from the streamlets to verify this match.
 * For the Cloudflow runtime, it needs to provide metadata so that it can be configured, scaled, and run as part of an application.
 * The inlets and outlets of a `Streamlet` have two functions:
@@ -97,7 +97,7 @@ The next section about message delivery semantics explains the options that are 
 [[message-delivery-semantics-spark]]
 == Message delivery semantics
 
-The message delivery semantics provided by Spark streamlets are determined by the guarantees provided by the underlying Spark sources and sinks used in the streamlet. Recall that we defined the different message delivery guarantees in xref:cloudflow-streamlets.adoc#message-delivery-semantics[Message delivery semantics].
+The message delivery semantics provided by Spark streamlets are determined by the guarantees provided by the underlying Spark sources and sinks used in the streamlet. Recall that we defined the different message delivery guarantees in xref:index.adoc#message-delivery-semantics[Message delivery semantics].
 
 Let's consider the following types of streamlets as forming a topology as illustrated in <<ing-proc-eggr>>:
 


### PR DESCRIPTION
When sharing the development content with the enterprise docs, I found some links that didn't resolve. I had to change a filename and a few xrefs to fix.

