### PR TITLE
Update doc section about installing the CLI

### DIFF
--- a/docs-source/docs/modules/get-started/pages/prepare-development-environment.adoc
+++ b/docs-source/docs/modules/get-started/pages/prepare-development-environment.adoc
@@ -16,7 +16,7 @@ First, make sure that you have the following installed:
 
 == Download and install the Cloudflow CLI
 
-Using one of the links below, download the Cloudflow CLI version appropriate for your platform and install it on your local system. Please make sure you have the executable in your path with proper permission settings. For Linux or MacOS, put the executables in `usr/local/bin` with permission settings of `755`.
+Using one of the links below, download the Cloudflow CLI version appropriate for your platform and install it on your local system by unzipping the archive and moving the executable into your `PATH`.
 
 IMPORTANT: If you have a Lightbend subscription, please use the instructions in the https://developer.lightbend.com/docs/cloudflow/current/install/run-script.html[Enterprise Features] documentation to install Cloudflow instead of the steps on this page.
   
@@ -26,6 +26,7 @@ IMPORTANT: If you have a Lightbend subscription, please use the instructions in 
 
 * https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-1.3.2.200-0d0f745-windows-amd64.tar.gz[Windows 64-bitLinux]
 
+Please make sure you have the executable in your path with proper permission settings. For Linux or MacOS, put the executables in `/usr/local/bin` with permission settings of `755`.
 
 NOTE:: On MacOS Catalina and later, the default behavior is to not allow unsigned executables downloaded from the internet. It is planned to sign the executable with an Apple developer certificate to fix this but in the mean time there is a very simple workaround. After downloading and unpacking the executable, please execute the following command to remove the "downloaded from the internet" filesystem flag that blocks the file from being executed:
 

--- a/docs-source/docs/modules/get-started/pages/prepare-development-environment.adoc
+++ b/docs-source/docs/modules/get-started/pages/prepare-development-environment.adoc
@@ -18,13 +18,11 @@ First, make sure that you have the following installed:
 
 Using one of the links below, download the Cloudflow CLI version appropriate for your platform and install it on your local system by unzipping the archive and moving the executable into your `PATH`.
 
-IMPORTANT: If you have a Lightbend subscription, please use the instructions in the https://developer.lightbend.com/docs/cloudflow/current/install/run-script.html[Enterprise Features] documentation to install Cloudflow instead of the steps on this page.
-  
 * https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-1.3.3.211-87a608c-darwin-amd64.tar.gz[MacOS]
 
 * https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-1.3.3.211-87a608c-linux-amd64.tar.gz[Linux]
 
-* https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-1.3.2.200-0d0f745-windows-amd64.tar.gz[Windows 64-bitLinux]
+* https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-1.3.3.211-87a608c-windows-amd64.tar.gz[Windows 64-bit]
 
 Please make sure you have the executable in your path with proper permission settings. For Linux or MacOS, put the executables in `/usr/local/bin` with permission settings of `755`.
 


### PR DESCRIPTION
Got some user feedback about the post-download steps being hard to spot so I moved them to after the download links.
